### PR TITLE
Do not depend on distutils for noble

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -17,7 +17,6 @@ Build-Depends: cmake,
                protobuf-compiler,
                python3,
                python3-dev,
-               python3-distutils,
                python3-protobuf
 Vcs-Browser: https://github.com/gazebosim/gz-msgs
 Vcs-Git: https://github.com/gazebo-release/gz-msgs11-release
@@ -76,7 +75,6 @@ Description: Set of message definitions used by robotics apps - CLI
 Package: python3-gz-msgs11
 Architecture: any
 Depends: libgz-msgs11 (= ${binary:Version}),
-         python3-distutils,
          python3-protobuf,
          ${misc:Depends},
          ${python3:Depends}


### PR DESCRIPTION
Same as: https://github.com/gazebo-release/gz-msgs10-release/pull/12/commits/43fc5029004ec3d368f270dd4562a301522d87b8

Should fix gz-msgs11 debbuilders on Noble.

PTAL @j-rivero @azeey 